### PR TITLE
Adding template files and rendering python script

### DIFF
--- a/src/render-config.py
+++ b/src/render-config.py
@@ -1,0 +1,41 @@
+from jinja2 import Environment, FileSystemLoader
+import yaml
+from pathlib import Path
+import sys
+
+if len(sys.argv) < 2:
+    print("Usage: python render-config.py <Ubuntu/WSL2>")
+    sys.exit(1)
+
+# Access the command-line variables
+os_conf_type = sys.argv[1]
+
+config_files = []
+
+# Ubuntu telegraf templates
+if os_conf_type == "Ubuntu":
+    config_files = [
+            "Ubuntu/docker-compose.yml",
+            "Ubuntu/conf/telegraf/telegraf.conf"
+            ]
+
+# Unsure if WSL2 is tested
+if os_conf_type == "WSL2":
+    config_files = [
+            "Windows-WSL2/docker-compose.yml",
+            "Windows-WSL2/conf/telegraf/telegraf.conf"
+            ]
+
+with open('config.yml', 'r') as file:
+    loaded_config = yaml.safe_load(file)
+
+jinja_env = Environment(loader=FileSystemLoader("templates/"))
+
+# Iterate over each configuration file
+for file_name in config_files:
+    template = jinja_env.get_template(file_name)
+    rendered_content = template.render(loaded_config)
+
+    file_dest_path = Path(file_name)
+    file_dest_path.parent.mkdir(exist_ok=True, parents=True)
+    file_dest_path.write_text(rendered_content)

--- a/templates/Ubuntu/conf/telegraf/telegraf.conf
+++ b/templates/Ubuntu/conf/telegraf/telegraf.conf
@@ -9,9 +9,9 @@
 
 # Outputs for ciscomdt
 [[outputs.influxdb_v2]]
-  urls = [ "http://<PUT NEW IP ADDRESS HERE>:8086" ]
-  token = "$INFLUXDB_TOKEN"
-  organization = "CBTNUGGETS-DEMO"
-  bucket = "CBTNUGGETS-DEMO-BUCKET"
+  urls = [ "http://{{ host }}:8086" ]
+  token = "{{ influxdb_token }}"
+  organization = "{{ influxdb_org }}"
+  bucket = "{{ influxdb_bucket }}"
 
 

--- a/templates/Ubuntu/docker-compose.yml
+++ b/templates/Ubuntu/docker-compose.yml
@@ -8,13 +8,13 @@ services:
       - "8086:8086"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
-      - DOCKER_INFLUXDB_INIT_USERNAME=admin
-      - DOCKER_INFLUXDB_INIT_PASSWORD=password123
-      - DOCKER_INFLUXDB_INIT_ORG=CBTNUGGETS-DEMO
-      - DOCKER_INFLUXDB_INIT_BUCKET=CBTNUGGETS-DEMO-BUCKET
-      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=veryverysecuretoken
+      - DOCKER_INFLUXDB_INIT_USERNAME={{ username }}
+      - DOCKER_INFLUXDB_INIT_PASSWORD={{ password }}
+      - DOCKER_INFLUXDB_INIT_ORG={{ influxdb_org }}
+      - DOCKER_INFLUXDB_INIT_BUCKET={{ influxdb_bucket }}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN={{ influxdb_token }}
     volumes:
-      - ./vols/:/var/lib/influxdb
+      - ./vols/:/var/lib/influxdb2
     restart: always
 
   grafana:
@@ -24,18 +24,23 @@ services:
       - "3000:3000"
     links:
       - influxdb
+    volumes:
+      - grafana_data:/var/lib/grafana
     restart: always
 
   telegraf:
     container_name: telegraf
-    image: telegraf:latest 
+    image: telegraf:latest
     ports:
-      - "57000:57000"   
+      - "57000:57000"
     environment:
-      - INFLUXDB_TOKEN=veryverysecuretoken
+      - INFLUXDB_TOKEN={{ influxdb_token }}
     links:
       - influxdb
     volumes:
       - ./conf/telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
       - /var/run/docker.sock:/var/run/docker.sock
     restart: always
+
+volumes:
+  grafana_data:

--- a/templates/Windows-WSL2/conf/telegraf/telegraf.conf
+++ b/templates/Windows-WSL2/conf/telegraf/telegraf.conf
@@ -6,9 +6,9 @@
 
 # Outputs for ciscomdt
 [[outputs.influxdb_v2]]
-  urls = [ "http://10.100.1.86:8086" ]
-  token = "$INFLUXDB_TOKEN"
-  organization = "CBTNUGGETS-DEMO"
-  bucket = "CBTNUGGETS-DEMO-BUCKET"
+  urls = [ "http://{{ host }}:8086" ]
+  token = "{{ influxdb_token }}"
+  organization = "{{ influxdb_org }}"
+  bucket = "{{ influxdb_bucket }}"
 
 

--- a/templates/Windows-WSL2/docker-compose.yml
+++ b/templates/Windows-WSL2/docker-compose.yml
@@ -8,13 +8,13 @@ services:
       - "8086:8086"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
-      - DOCKER_INFLUXDB_INIT_USERNAME=admin
-      - DOCKER_INFLUXDB_INIT_PASSWORD=password123
-      - DOCKER_INFLUXDB_INIT_ORG=CBTNUGGETS-DEMO
-      - DOCKER_INFLUXDB_INIT_BUCKET=CBTNUGGETS-DEMO-BUCKET
-      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=veryverysecuretoken
+      - DOCKER_INFLUXDB_INIT_USERNAME={{ username }}
+      - DOCKER_INFLUXDB_INIT_PASSWORD={{ password }}
+      - DOCKER_INFLUXDB_INIT_ORG={{ influxdb_org }}
+      - DOCKER_INFLUXDB_INIT_BUCKET={{ influxdb_bucket }}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN={{ influxdb_token }}
     volumes:
-      - ./vols/:/var/lib/influxdb2
+      - ./vols/:/var/lib/influxdb
     restart: always
 
   grafana:
@@ -24,8 +24,6 @@ services:
       - "3000:3000"
     links:
       - influxdb
-    volumes:
-      - grafana_data:/var/lib/grafana
     restart: always
 
   telegraf:
@@ -34,13 +32,10 @@ services:
     ports:
       - "57000:57000"
     environment:
-      - INFLUXDB_TOKEN=veryverysecuretoken
+      - INFLUXDB_TOKEN={{ influxdb_token }}
     links:
       - influxdb
     volumes:
       - ./conf/telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
       - /var/run/docker.sock:/var/run/docker.sock
     restart: always
-
-volumes:
-  grafana_data:


### PR DESCRIPTION
Added template rendering script
Converted docker-compose.yml and telegraf.conf to template files

When script is run, with args "Ubuntu" or "WSL2" it will generate the rendered config files appropriately

Example: python3 render-config.py Ubuntu